### PR TITLE
Correct incorrect deletion when a project change or there is a new version available

### DIFF
--- a/app/src/main/java/com/ciandt/dragonfly/example/data/local/LocalDataSource.kt
+++ b/app/src/main/java/com/ciandt/dragonfly/example/data/local/LocalDataSource.kt
@@ -41,7 +41,9 @@ class LocalDataSource(val database: AppDatabase) {
     }
 
     fun update(project: ProjectEntity) = database.runInTransaction {
-        versionDao.delete(project.id)
+        if (project.versions.isEmpty()) {
+            versionDao.delete(project.id)
+        }
         insert(project)
     }
 


### PR DESCRIPTION
@ivamluz Space added!

The deletion is necessary when we have a project with versions and then the versions are removed. So, we need to remove this information at client.

But if we always delete, we wont know if the user downloaded a model and need to update now.